### PR TITLE
Generate manifests from a directory of images and obtain label and description from CSV metadata file

### DIFF
--- a/img_iiif_s3.rb
+++ b/img_iiif_s3.rb
@@ -5,6 +5,7 @@ IiifS3::Manifest.prepend IiifS3::ManifestOverride
 
 # path to the image files end with "obj_id/image.tif" 
 @dir_url = "https://img.cloud.lib.vt.edu/Ms1990_057_Chadeayne/Edited/Ms1990_057_Box1/Ms1990_057_B001_F001_001_LHJClips_Ms/Access"
+@csv_url = "https://scholar-jekyll.dev.vtlibcloud.com/iiftest/Chadeayne_Ms1990_057_Box1.csv"
 # Setup Temporary stores
 @data = []
 # Set up configuration variables
@@ -17,20 +18,46 @@ opts[:image_types] = [".jpg", ".tif", ".jpeg", ".tiff"]
 opts[:document_file_types] = [".pdf"]
 opts[:prefix] = "iiif_s3_test/#{@dir_url.split('/')[3..-3].join('/')}"
 
+def create_directories(path)
+  FileUtils.mkdir_p(path) unless Dir.exists?(path)
+end
+
+def get_metadata(csv_url, id)
+  begin
+    open(csv_url) do |u|
+      csv_file_name = File.basename(csv_url)
+      csv_file_path = "#{@config.output_dir}/#{csv_file_name}"
+      unless File.exists?(csv_file_path)
+        File.open(csv_file_path, 'wb') { |f| f.write(u.read) }
+      end
+      CSV.read(csv_file_path, 'r:bom|utf-8', headers: true) do |row|
+	puts row['Identifier']
+        if row['Identifier'] == id
+	  return row['Title'], row['Description']
+	end
+      end
+      puts "No matching Identifier found"
+    end
+  rescue
+    puts "No CSV file found"
+  end
+end
+
 def add_image(file, id)
   # name should be either as numerical or identifier_numerical,
   # such as Ms1990_025_Per_Awd_B001_F001_006_001.tif or 001.tif
   name = File.basename(file, File.extname(file))
   page_num = name.split("_").last.to_i
-
+  label, description = get_metadata(@csv_url, id)
+  puts label, description
   obj = {
     "path" => "#{file}",
     "id"       => id,
-    "label"    => "Certificate and program for YWCA Leader Luncheon VI, March 27, 1980 (Ms1990-025)",
+    "label"    => label,
     "is_master" => page_num == 1,
     "page_number" => page_num,
     "is_document" => false,
-    "description" => "Leader Luncheon certificate of achievement honoring the leadership of women in the economic, civic, and cultural life of Los Angeles. Lorraine Rudoff's name appears on page 8 of the luncheon program.",
+    "description" => description,
     "attribution" => "Special Collections, University Libraries, Virginia Tech",
   }  
 
@@ -41,39 +68,40 @@ end
 
 iiif = IiifS3::Builder.new(opts)
 @config = iiif.config
+
 # generate a path on disk for "output_dir/prefix/id" 
 path = "#{@config.output_dir}#{@config.prefix}/"
-FileUtils.mkdir_p(path) unless Dir.exists?(path)
+create_directories(path)
 # generate a path on disk for "output_dir/prefix/image_dir"
 img_dir = "#{path}#{@config.image_directory_name}/".split("/")[0...-1].join("/")
-FileUtils.mkdir_p(img_dir) unless Dir.exists?(img_dir)
+create_directories(img_dir)
 
 id = @dir_url.split("/")[-2]
 # write originial images to disk
 file_dir = "#{@config.output_dir}/#{id}"
-Dir.mkdir(file_dir) unless Dir.exists?(file_dir)
+create_directories(file_dir)
 # We don't have access permission to the bucket, so just enumerate all the files
   
-file_base_name = "#{id}_001"
-file = "#{file_base_name}.tif"
-file_path = "#{@config.output_dir}/#{id}/#{file}"
+img_file_base_name = "#{id}_001"
+img_file = "#{img_file_base_name}.tif"
+img_file_path = "#{@config.output_dir}/#{id}/#{img_file}"
 # image object as s3 link
-url = "#{@dir_url}/#{file}"
+url = "#{@dir_url}/#{img_file}"
 can_open = true
 while can_open 
   begin	
     open(url) do |u|
-      File.open(file_path, 'wb') { |f| f.write(u.read) }
-      image_record = add_image(file_path, id)
-      file_base_name = file_base_name.next
-      file = "#{file_base_name}.tif"
-      file_path = "#{@config.output_dir}/#{id}/#{file}"
-      url = "#{@dir_url}/#{file}"
-      can_open = false if file_base_name == "#{id}_002"
+      File.open(img_file_path, 'wb') { |f| f.write(u.read) }
+      add_image(img_file_path, id)
+      img_file_base_name = img_file_base_name.next
+      img_file = "#{img_file_base_name}.tif"
+      img_file_path = "#{@config.output_dir}/#{id}/#{img_file}"
+      url = "#{@dir_url}/#{img_file}"
+      can_open = false if img_file_base_name == "#{id}_002"
     end
   rescue
     can_open = false
   end
 end
-iiif.load(@data)
-iiif.process_data
+#iiif.load(@data)
+#iiif.process_data


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1774) (:star:)

# What does this Pull Request do? (:star:)
Using iiif_s3 gem, this ruby script processes all the images within an AWS S3 directory, generates IIIF level 0 compatible image manifest/tiles and uploads them to AWS S3 static server. The script also reads from the corresponding CSV metadata file to generate label and description metadata.

# What's the changes? (:star:)

* Read CSV file and extract two metadata fields.

# How should this be tested?

* Use LIBTD-1774 Branch
* export AWS_ACCESS_KEY_ID=""
* export AWS_SECRET_ACCESS_KEY=""
* export AWS_BUCKET_NAME=""
* export export AWS_REGION=""
* Make sure "@dir_url" has public accessible images 
* Make sure "@csv_url" has public accessible csv file with matching Identifier
* Run "ruby img_iiif_s3.rb"
* You can ignore the warning messages, such as "identify-im6.q16: Incompatible type for "RichTIFFIPTC"; tag ignored. `TIFFFetchNormalTag' @ warning/tiff.c/TIFFWarnings/912.
* Since the generation process is very time consuming, you can adjust how many images are included in the manifest by modifying line 105: "img_file_base_name == "#{id}_003", change 3 to how many images you would like to generate.
* If you want to regenerate manifest/tiles from scratch, you have to remove the folder under tmp directory, this is intentionally done to avoid regenerating existing manifest/tiles.
* Go to your AWS_BUCKET_NAME bucket, you can find manifest/tiles. 
* Go to "http://projectmirador.org/demo/", click on the left corner four-square drop down list, choose "Replace Object" and paste the manifest json link to load the images.

# Interested parties
Tag (@pmather ) interested parties

(:star:) Required fields
