### PR TITLE
LIBTD-1789: Set more arguments and option to generate tiles/manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ e.g. Special collection folder example: Ms1990_057_Chadeayne/Edited/Ms1990_057_B
 ```
 4. Run the Ruby script:
 ```
-$ ruby create_iiif_s3.rb Chadeayne_Ms1990_057_Box1.csv Ms1990_057_Chadeayne/Edited/Ms1990_057_Box1/Ms1990_057_B001_F001_001_LHJClips_Ms/Access/
+$ ruby create_iiif_s3.rb Chadeayne_Ms1990_057_Box1.csv Ms1990_057_Chadeayne/Edited/Ms1990_057_Box1/Ms1990_057_B001_F001_001_LHJClips_Ms/Access/ https://img.cloud.lib.vt.edu iiif_s3_test --upload_to_s3=false
 ```

--- a/create_iiif_s3.rb
+++ b/create_iiif_s3.rb
@@ -56,8 +56,8 @@ def add_image(file, id)
   @data.push IiifS3::ImageRecord.new(obj)
 end
 
-if ARGV.length != 2
-  puts "Usage: ruby create_iiif_s3.rb csv_metadata_file image_folder_path"
+if ARGV.length != 5
+  puts "Usage: ruby create_iiif_s3.rb csv_metadata_file image_folder_path manifest_base_path manifest_root_folder --upload_to_s3=false"
   exit
 end
 
@@ -72,13 +72,17 @@ end
 @data = []
 # Set up configuration variables
 opts = {}
+opts[:base_url] = ARGV[2]
 opts[:image_directory_name] = "tiles"
 opts[:output_dir] = "tmp"
 opts[:variants] = { "reference" => 600, "access" => 1200}
-opts[:upload_to_s3] = true
+# get the flag if upload to S3 or not
+args = Hash[ ARGV.join(' ').scan(/--?([^=\s]+)(?:=(\S+))?/) ]
+opts[:upload_to_s3] = (args["upload_to_s3"] == 'true' ? true : false)
 opts[:image_types] = [".jpg", ".tif", ".jpeg", ".tiff"]
 opts[:document_file_types] = [".pdf"]
-opts[:prefix] = "#{@input_folder.split('/')[1..-3].join('/')}"
+# prefix uses manifest_root_folder
+opts[:prefix] = "#{ARGV[3]}/#{@input_folder.split('/')[0..-3].join('/')}"
 
 iiif = IiifS3::Builder.new(opts)
 @config = iiif.config


### PR DESCRIPTION

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1789) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
The PR sets more command line arguments and hash option to be called by the ruby script.

# What's the changes? (:star:)

* Add an argument to set the base url for manifests/tiles
* Add an argument to set the root folder for manifests/tiles
* Add option to upload the manifests/tiles to S3 or not
* Update the README accordingly

# How should this be tested?

* In branch 1789
* Example command: ruby create_iiif_s3.rb Chadeayne_Ms1990_057_Box1.csv Ms1990_057_Chadeayne/Edited/Ms1990_057_Box1/Ms1990_057_B001_F001_001_LHJClips_Ms/Access/ https://img.cloud.lib.vt.edu iiif_s3_test --upload_to_s3=false

# Interested parties
Tag (@zoto724 ) interested parties

(:star:) Required fields
