### PR TITLE
LIBTD-1797: Make the image folder path more flexible

### DIFF
--- a/create_iiif_s3.rb
+++ b/create_iiif_s3.rb
@@ -14,9 +14,7 @@ def get_metadata(csv_url, id)
     open(csv_url) do |u|
       csv_file_name = File.basename(csv_url)
       csv_file_path = "#{@config.output_dir}/#{csv_file_name}"
-      unless File.exists?(csv_file_path)
-        File.open(csv_file_path, 'wb') { |f| f.write(u.read) }
-      end
+      File.open(csv_file_path, 'wb') { |f| f.write(u.read) }
       CSV.read(csv_file_path, 'r:bom|utf-8', headers: true).each do |row|
         if row.header?("Identifier")
           if row.field("Identifier") == id
@@ -62,9 +60,11 @@ if ARGV.length != 5
 end
 
 @csv_url = ARGV[0]
-# path to the image files end with "obj_id/image.tif" 
-@input_folder = ARGV[1]
-
+csv_name = File.basename(@csv_url)
+collection_id = csv_name.scan(/^Ms\d{4}_\d{3}/)[0]
+# path to the image files end with "obj_id/image.tif"
+image_folder_path = ARGV[1]
+@input_folder = image_folder_path.slice(image_folder_path.index("#{collection_id}")..-1)
 # read files in the input_folder
 @image_files = Dir[@input_folder + "*"].sort
 


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1797) (:star:)

# What does this Pull Request do? (:star:)
This PR makes sure that the second argument passed to the script would be flexible path, e.g., absolute/relative/partial path

# What's the changes? (:star:)

* Make sure the CSV file will be overwritten when the script reruns
* Get the relative path from the second argument passed to the script by matching up collection's id

# How should this be tested?

* Run script as something like ruby create_iiif_s3.rb /some/path/to/csv/file/Ms1990_057_Chadeayne/Ms1990_025_Box1/Ms1990_057_Box1.csv /some/path/to/image/folder/Ms1990_057_Chadeayne/Ms1990_057_Box1/Ms1990_057_B001_F001_001_LHJClips_Ms/Access/ https://img.cloud.lib.vt.edu iiif_s3_test --upload_to_s3=false

# Additional Notes:

* What branch to be used for testing this PR? LIBTD-1797

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
