### PR TITLE
LIBTD-2039: Set page number based on the ordering index in the sorted…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # image-iiif-s3
-This repository contains Ruby script that can be used to generate IIIF level 0 compatible image presentation manifests and tiles, and then to upload them to Amazon S3 bucket for static serving.
+This repository contains Ruby script that can be used to generate IIIF level 0 compatible image presentation manifests and tiles, which can be uploaded to Amazon S3 bucket for static serving.
 
 # Local Development Installation
 The development environment can be set up using [VTUL/iiif_s3-vagrant](https://github.com/VTUL/iiif_s3-vagrant). To deploy on your local machine, first install Vagrant, Ansible, and VirtualBox, then follow the steps below.
@@ -20,15 +20,23 @@ $ export AWS_SECRET_ACCESS_KEY=""
 $ export AWS_BUCKET_NAME=""
 $ export AWS_REGION=""
 ```
-2. Prepare a CSV file
+2. A CSV metadata file
 ```
 e.g. Chadeayne_Ms1990_057_Box1.csv
 ```
-3. A folder with image files
+3. A folder with image files 
 ```
 e.g. Special collection folder example: Ms1990_057_Chadeayne/Edited/Ms1990_057_Box1/Ms1990_057_B001_F001_001_LHJClips_Ms/Access/
 ```
 4. Run the Ruby script:
-```
-$ ruby create_iiif_s3.rb Chadeayne_Ms1990_057_Box1.csv Ms1990_057_Chadeayne/Edited/Ms1990_057_Box1/Ms1990_057_B001_F001_001_LHJClips_Ms/Access/ https://img.cloud.lib.vt.edu iiif_s3_test --upload_to_s3=false
-```
+    * Print help (note that with -u or --upload_to_s3 boolean argument it will upload to S3, otherwise no argument turns the option off):
+    ```
+    $ ruby create_iiif_s3.rb -h
+    ```
+    * Examples:
+    ```
+    $ ruby create_iiif_s3.rb -m Chadeayne_Ms1990_057_Box1.csv -i Ms1990_057_Chadeayne/Edited/Ms1990_057_Box1/Ms1990_057_B001_F001_001_LHJClips_Ms/Access/ -b https://img.cloud.lib.vt.edu -r iiif_s3_test -u
+    ```
+    ```
+    $ ruby create_iiif_s3.rb -m Chadeayne_Ms1990_057_Box1.csv -i Ms1990_057_Chadeayne/Edited/Ms1990_057_Box1/Ms1990_057_B001_F001_001_LHJClips_Ms/Access/ -b https://img.cloud.lib.vt.edu -r iiif_s3_test
+    ```

--- a/create_iiif_s3.rb
+++ b/create_iiif_s3.rb
@@ -38,11 +38,9 @@ def get_metadata(csv_url, id)
   end
 end
 
-def add_image(file, id)
-  # name should be either as numerical or identifier_numerical,
-  # such as Ms1990_025_Per_Awd_B001_F001_006_001.tif or 001.tif
+def add_image(file, id, idx)
   name = File.basename(file, File.extname(file))
-  page_num = name.split("_").last.to_i
+  page_num = idx + 1
   label, description = get_metadata(@csv_url, id)
   obj = {
     "path" => "#{file}",
@@ -153,8 +151,8 @@ create_directories(img_dir)
 
 id = @input_folder.split("/")[-2]
 
-for image_file in @image_files
-  add_image(image_file, id)
+@image_files.each_with_index do |image_file, idx|
+  add_image(image_file, id, idx)
 end
 
 iiif.load(@data)


### PR DESCRIPTION
… image sequence instead of file name suffix

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-2039) (:star:)

# What does this Pull Request do? (:star:)
This PR sets page number for each image in an image sequence using the ordering index in the sorted list. The sorting is based on the file names of the images. Subsequently, the first image in the sorted list will be set as the primary and thumbnail image of the image sequence.
 
# What's the changes? (:star:)

* Set page number using the ordering index of the sorted list instead of numerical value in the file name suffix

# How should this be tested?

* create_iiif_s3.rb -m csv_metadata_file -i image_folder_path -b manifest_base_path -r manifest_root_folder -[no-]u

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields
